### PR TITLE
Removed unnecessary transformers dependency

### DIFF
--- a/monomorphic.cabal
+++ b/monomorphic.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                monomorphic
-version:             0.0.3.1
+version:             0.0.3.2
 synopsis:            Library to convert polymorphic datatypes to/from its monomorphic represetation
 description:         This library provides the type-class and functions to convert between polymorphic data-types and its monomorphic representation type, such as length-indexed vectors, singletons for type-level natural numbers, etc.
 homepage:            https://github.com/konn/monomorphic
@@ -23,4 +23,3 @@ library
   exposed-modules:     Data.Type.Monomorphic
   -- other-modules:       
   build-depends:       base             >= 2.0 && < 5
-               ,       transformers     >= 0.2 && < 0.4


### PR DESCRIPTION
Transfomers are not really needed here, are they?
But this unnecessary constrain then limits the transformers version that can be used with sized-vector.

Thanks!
Cheers
